### PR TITLE
chore: Added docker publishing for git service

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,43 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [ "main" ]
+  release:
+    types: [created]
+
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/hxckr-git-service
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: ./git-service
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-# Hxckr Infra Repo
+# HXCKR Infrastructure
 
-> This repo contains service to run the infrasturacture for the hxckr project which include:
+This repository contains the infrastructure code for the HXCKR project.
+
+## Components
+
+- [Git Service](./git-service/README.md): A web service that interacts with Soft Serve git server, allowing for Soft Serve commands to be accessible over HTTP.
 
 1. Service for interacting with the soft serve git server(please to [Git Service Setup](./git-service/SETUP.md))

--- a/git-service/Dockerfile
+++ b/git-service/Dockerfile
@@ -1,0 +1,33 @@
+# Use the official Rust image as the base image
+FROM rust:1.76 as builder
+
+# Create a new empty shell project
+RUN USER=root cargo new --bin git-service
+WORKDIR /git-service
+
+# Copy our manifests
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./Cargo.toml ./Cargo.toml
+
+# Build only the dependencies to cache them
+RUN cargo build --release
+RUN rm src/*.rs
+
+# Copy the source code
+COPY ./src ./src
+
+# Build for release
+RUN rm ./target/release/deps/git_service*
+RUN cargo build --release
+
+# Final stage
+FROM debian:bullseye-slim
+
+# Install OpenSSL and ca-certificates
+RUN apt-get update && apt-get install -y openssl ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Copy the build artifact from the builder stage
+COPY --from=builder /git-service/target/release/git-service .
+
+# Set the startup command
+CMD ["./git-service"]

--- a/git-service/README.md
+++ b/git-service/README.md
@@ -1,0 +1,32 @@
+# Git Service
+
+The Git Service is a web service that interacts with a Soft Serve git server, providing HTTP endpoints to perform various git-related operations.
+
+## What the service does
+
+This service acts as a bridge between HTTP clients and a Soft Serve git server. It provides the following functionalities:
+
+1. Create repositories: Allows clients to create new git repositories on the Soft Serve server.
+2. Generate authentication tokens: Creates and returns authentication tokens for accessing repositories.
+3. Return authenticated URLs: Provides URLs with built-in authentication tokens for easy access to repositories.
+
+The service essentially wraps Soft Serve's SSH-based commands into HTTP endpoints, making it easier to integrate git operations into web applications or other services that prefer HTTP interactions.
+
+## How it is published
+
+The Git Service is containerized using Docker and published using GitHub Actions. Here's an overview of the process:
+
+1. Dockerfile: The service uses a multi-stage Dockerfile to build the Rust application and create a lean runtime image.
+
+2. GitHub Actions: A workflow (`.github/workflows/docker-publish.yml`) is set up to automatically build and publish the Docker image when changes are pushed to the main branch or a new release is created.
+
+3. Multi-platform support: The Docker image is built for both `linux/amd64` and `linux/arm64` platforms.
+
+4. DockerHub: The built images are pushed to DockerHub under the repository `${DOCKERHUB_USERNAME}/hxckr-git-service`.
+
+5. Tagging: Each image is tagged with:
+   - `latest`: Always points to the most recent build
+   - The git commit SHA
+   - The git reference name (branch or tag)
+
+To use the published Docker image, you can pull it from DockerHub:


### PR DESCRIPTION
# Add Docker support and documentation for Git Service

This PR adds Docker support for the Git Service, sets up automated publishing, and improves documentation.

## Changes

1. **Added Dockerfile for Git Service**
   - Created `git-service/Dockerfile`
   - Uses multi-stage build for optimized image size
   - Builds the Rust application and creates a lean runtime image

2. **Added GitHub Actions workflow for Docker publishing**
   - Created `.github/workflows/docker-publish.yml`
   - Automatically builds and publishes Docker image on pushes to main and new releases
   - Supports multi-platform builds (linux/amd64, linux/arm64)
   - Publishes to DockerHub with appropriate tags

3. **Added README for Git Service**
   - Created `git-service/README.md`
   - Describes the purpose and functionality of the Git Service
   - Explains how the service is published using Docker and GitHub Actions

4. **Updated project README**
   - Linked the new Git Service README in the main project README

## Testing

- [x] Verify that the Dockerfile builds successfully
- [x] Test the GitHub Actions workflow to ensure proper image building and publishing
- [ ] Check that the published Docker image runs correctly

## Next Steps

- Consider adding automated tests for the Git Service
- Explore options for versioning the Docker images beyond using git SHA and ref name