### PR TITLE
fix: Now using ubuntu for better ssl support

### DIFF
--- a/git-service/Dockerfile
+++ b/git-service/Dockerfile
@@ -21,10 +21,12 @@ RUN rm ./target/release/deps/git_service*
 RUN cargo build --release
 
 # Final stage
-FROM debian:bullseye-slim
+FROM ubuntu:22.04
 
 # Install OpenSSL and ca-certificates
-RUN apt-get update && apt-get install -y openssl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y openssl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 # Copy the build artifact from the builder stage
 COPY --from=builder /git-service/target/release/git-service .


### PR DESCRIPTION
# Switch Base Image to Ubuntu 22.04 to Resolve SSL Library Issues

## Change Summary
This PR updates the final stage of our Dockerfile from `debian:bullseye-slim` to `ubuntu:22.04` to address runtime errors related to missing SSL libraries.

## Rationale
- **Primary Reason**: Resolves runtime errors caused by missing SSL libraries in the Debian Slim image.
- Ubuntu 22.04 provides better out-of-the-box support for the SSL libraries required by our application.
- This change ensures our service can establish secure connections without additional configuration.

## Changes Made
```dockerfile
# Final stage
FROM ubuntu:22.04

# Install OpenSSL and ca-certificates
RUN apt-get update && \
    apt-get install -y openssl ca-certificates && \
    rm -rf /var/lib/apt/lists/*

# ... rest of the Dockerfile remains unchanged ...
```

## Impact
- Resolves SSL-related runtime errors, improving the stability and security of our service.
- Slight increase in base image size (Ubuntu is typically larger than Debian Slim).
- Ensures compatibility with OpenSSL and other SSL-related dependencies.

## Testing
- [x] Verify that the service builds successfully with the new base image.
- [x] Confirm that SSL-related errors are resolved in the runtime environment.